### PR TITLE
PMM-1519 add prometheus stop timeout

### DIFF
--- a/rhel/SOURCES/prometheus.service
+++ b/rhel/SOURCES/prometheus.service
@@ -11,6 +11,7 @@ EnvironmentFile=-/etc/sysconfig/prometheus
 ExecStart=/usr/sbin/prometheus -web.listen-address $WEB_LISTEN_ADDRESS -config.file=/etc/prometheus.yml -storage.local.path $STORAGE_LOCAL_PATH -web.console.templates=/usr/share/prometheus/consoles -web.console.libraries=/usr/share/prometheus/console_libraries $OPTIONS
 Restart=on-failure
 RestartSec=10s
+TimeoutStopSec=300s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
issue: large installations cannot be stopped successfully without long crash recovery on start.