### PR TITLE
PMM-3705 Set empty branch name.

### DIFF
--- a/rhel/SPECS/pmm-managed.spec
+++ b/rhel/SPECS/pmm-managed.spec
@@ -51,6 +51,7 @@ export GOPATH=$(pwd)/
 
 export PMM_RELEASE_VERSION=%{full_pmm_version}
 export PMM_RELEASE_FULLCOMMIT=%{commit}
+export PMM_RELEASE_BRANCH=""
 
 cd src/github.com/percona/pmm-managed
 make release


### PR DESCRIPTION
That is harmless but removes warning during a build.