### PR TITLE
PMM-4931 pmm-managed-init

### DIFF
--- a/rhel/SPECS/pmm-managed.spec
+++ b/rhel/SPECS/pmm-managed.spec
@@ -13,7 +13,7 @@
 %global commit		8f3d007617941033867aea6a134c48b39142427f
 %global shortcommit	%(c=%{commit}; echo ${c:0:7})
 %define build_timestamp %(date -u +"%y%m%d%H%M")
-%define release         14
+%define release         15
 %define rpm_release     %{release}.%{build_timestamp}.%{shortcommit}%{?dist}
 
 %define full_pmm_version 2.0.0

--- a/rhel/SPECS/pmm-managed.spec
+++ b/rhel/SPECS/pmm-managed.spec
@@ -56,7 +56,7 @@ make release
 install -d -p %{buildroot}%{_bindir}
 install -d -p %{buildroot}%{_sbindir}
 install -p -m 0755 bin/pmm-managed %{buildroot}%{_sbindir}/pmm-managed
-install -p -m 0755 bin/pmm-managed %{buildroot}%{_sbindir}/pmm-managed-init
+install -p -m 0755 bin/pmm-managed-init %{buildroot}%{_sbindir}/pmm-managed-init
 
 
 %files

--- a/rhel/SPECS/pmm-managed.spec
+++ b/rhel/SPECS/pmm-managed.spec
@@ -13,7 +13,7 @@
 %global commit		8f3d007617941033867aea6a134c48b39142427f
 %global shortcommit	%(c=%{commit}; echo ${c:0:7})
 %define build_timestamp %(date -u +"%y%m%d%H%M")
-%define release         13
+%define release         14
 %define rpm_release     %{release}.%{build_timestamp}.%{shortcommit}%{?dist}
 
 %define full_pmm_version 2.0.0
@@ -56,14 +56,19 @@ make release
 install -d -p %{buildroot}%{_bindir}
 install -d -p %{buildroot}%{_sbindir}
 install -p -m 0755 bin/pmm-managed %{buildroot}%{_sbindir}/pmm-managed
+install -p -m 0755 bin/pmm-managed %{buildroot}%{_sbindir}/pmm-managed-init
 
 
 %files
 %license src/%{provider_prefix}/LICENSE
 %doc src/%{provider_prefix}/README.md
 %{_sbindir}/pmm-managed
+%{_sbindir}/pmm-managed-init
 
 
 %changelog
+* Tue Fed 11 2020 Mykyta Solomko <mykyta.solomko@percona.com> - 2.0.0-14
+- added pmm-managed-init
+
 * Thu Sep  5 2019 Viacheslav Sarzhan <slava.sarzhan@percona.com> - 2.0.0-10
 - init version

--- a/rhel/SPECS/pmm-managed.spec
+++ b/rhel/SPECS/pmm-managed.spec
@@ -67,7 +67,7 @@ install -p -m 0755 bin/pmm-managed %{buildroot}%{_sbindir}/pmm-managed-init
 
 
 %changelog
-* Tue Fed 11 2020 Mykyta Solomko <mykyta.solomko@percona.com> - 2.0.0-14
+* Tue Feb 11 2020 Mykyta Solomko <mykyta.solomko@percona.com> - 2.0.0-14
 - added pmm-managed-init
 
 * Thu Sep  5 2019 Viacheslav Sarzhan <slava.sarzhan@percona.com> - 2.0.0-10


### PR DESCRIPTION
Added `pmm-managed-init` binary into spec

https://jira.percona.com/browse/PMM-4931

FB:  https://github.com/Percona-Lab/pmm-submodules/pull/684

Related PRs:
 - https://github.com/percona/pmm-server-packaging/pull/112
 - https://github.com/percona/pmm-server/pull/192
 - https://github.com/percona/pmm-managed/pull/341
 - https://github.com/percona/qan-api2/pull/81