### PR TITLE
PMM-5558 alertmanager spec fix

### DIFF
--- a/rhel/SPECS/alertmanager.spec
+++ b/rhel/SPECS/alertmanager.spec
@@ -33,7 +33,7 @@ BuildRequires:   golang >= 1.12.0
 %prep
 %setup -q -n %{repo}-%{commit}
 mkdir -p ./build/src/github.com/prometheus
-cp -r $(pwd) ./build/src/github.com/prometheus/alertmanager
+ln -s $(pwd) ./build/src/github.com/prometheus/alertmanager
 
 
 %build

--- a/rhel/SPECS/alertmanager.spec
+++ b/rhel/SPECS/alertmanager.spec
@@ -13,7 +13,7 @@
 
 Name:           percona-%{repo}
 Version:        0.20.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The Prometheus monitoring system and time series database
 License:        ASL 2.0
 URL:            https://%{provider_prefix}


### PR DESCRIPTION
Switched back to symlinks in `GOPATH` because other variants looks more like ugly workaround, rather then solution.

Unfortunately, there's no way to avoid using symbolic links inside of `GOPATH`, at the current stage. Because directory path created by `%setup` macro is being inherited by the next build stages (such as `%build` and `%files`).

There's couple of variants if we want neat output/logs without confusing paths in them:
1. Split build and packaging to separate steps, and package pre-built binaries;
2. Add separate build script (for all packages) that will build sources Golang style, but this will require separate Git repo.
