### PR TITLE
PMM-6516 clickhouse build version fix

### DIFF
--- a/rhel/SPECS/clickhouse.spec
+++ b/rhel/SPECS/clickhouse.spec
@@ -6,7 +6,7 @@
 
 Name:           percona-clickhouse
 Version:        19.7.5.27
-Release:        1.stable%{?dist}
+Release:        stable%{?dist}
 Summary:        A free analytic DBMS for big data
 Group:          Applications/Databases
 License:        Apache-2.0


### PR DESCRIPTION
Fixed build version for clickhouse.
```
+ mkdir -p /home/builder/clickhouse-rpm/rpmbuild/BUILD /home/builder/clickhouse-rpm/rpmbuild/BUILDROOT /home/builder/clickhouse-rpm/rpmbuild/RPMS /home/builder/clickhouse-rpm/rpmbuild/SOURCES /home/builder/clickhouse-rpm/rpmbuild/SPECS /home/builder/clickhouse-rpm/rpmbuild/SRPMS /home/builder/clickhouse-rpm/rpmbuild/TMP
+ echo '====> Create RPM packages'
+ echo 'Cloning from github v19.7.5.27-1.stable into /home/builder/clickhouse-rpm/rpmbuild/SOURCES/ClickHouse-19.7.5.27-1.stable'
+ cd /home/builder/clickhouse-rpm/rpmbuild/SOURCES
====> Create RPM packages
Cloning from github v19.7.5.27-1.stable into /home/builder/clickhouse-rpm/rpmbuild/SOURCES/ClickHouse-19.7.5.27-1.stable
+ echo '====> Clone ClickHouse repo'
+ git clone https://github.com/yandex/ClickHouse ClickHouse-19.7.5.27-1.stable
====> Clone ClickHouse repo
Cloning into 'ClickHouse-19.7.5.27-1.stable'...
+ cd ClickHouse-19.7.5.27-1.stable
+ echo '====> Checkout specific tag v19.7.5.27-1.stable'
+ git checkout v19.7.5.27-1.stable
====> Checkout specific tag v19.7.5.27-1.stable
error: pathspec 'v19.7.5.27-1.stable' did not match any file(s) known to git.
script returned exit code 1
```